### PR TITLE
Detect a previously used frequency

### DIFF
--- a/day1/day1.functions.js
+++ b/day1/day1.functions.js
@@ -1,0 +1,23 @@
+const calculateFrequency = frequencies => {
+  return frequencies
+    .split('\n')
+    .reduce((accumulator, currentValue) => accumulator + parseInt(currentValue), 0);
+}
+
+const calculateDuplicateFrequency = frequencies => {
+  const cache = [];
+  let currentFrequency = 0;
+  let i = 0;
+  frequencies = frequencies.split('\n');
+
+  while(!cache.includes(currentFrequency)) {
+    cache.push(currentFrequency);
+    currentFrequency = currentFrequency + parseInt(frequencies[i]);
+    i = i === frequencies.length -1 ? 0 : i + 1;
+  }
+
+  return currentFrequency;;
+}
+
+module.exports = { calculateFrequency, calculateDuplicateFrequency };
+

--- a/day1/day1.part1.js
+++ b/day1/day1.part1.js
@@ -1,8 +1,0 @@
-const calculateFrequency = frequencies => {
-  return frequencies
-    .split('\n')
-    .reduce((accumulator, currentValue) => accumulator + parseInt(currentValue), 0);
-}
-
-module.exports = { calculateFrequency };
-

--- a/day1/day1.test.js
+++ b/day1/day1.test.js
@@ -1,5 +1,5 @@
 const { FREQUENCY_CHANGES } = require('./day1.input.js');
-const { calculateFrequency } = require('./day1.part1.js');
+const { calculateFrequency, calculateDuplicateFrequency } = require('./day1.functions.js');
 
 describe('Day 1', () => {
   describe('Part 1', () => {
@@ -7,5 +7,11 @@ describe('Day 1', () => {
       expect(calculateFrequency(FREQUENCY_CHANGES)).toEqual(427);
     });
   });
+
+  describe('Part 2', () => {
+    it('Should calculate the first duplicate frequency given numerous freqnuency changes', () => {
+      expect(calculateDuplicateFrequency(FREQUENCY_CHANGES)).toEqual(341);
+    })
+  })
 });
 


### PR DESCRIPTION
The day 1 part two challenge was to calculate if a frequency has been
previously used given multiple changes in frequency.

From [Advent of Code Day 1 Instructions](https://adventofcode.com/2018/day/1):
>You notice that the device repeats the same frequency change list over and over. To calibrate the device, you need to find the first frequency it reaches twice.
>For example, using the same list of changes above, the device would loop as follows:

>Current frequency  0, change of +1; resulting frequency  1.
Current frequency  1, change of -2; resulting frequency -1.
Current frequency -1, change of +3; resulting frequency  2.
Current frequency  2, change of +1; resulting frequency  3.
(At this point, the device continues from the start of the list.)
Current frequency  3, change of +1; resulting frequency  4.
Current frequency  4, change of -2; resulting frequency  2, which has already been seen.

>In this example, the first frequency reached twice is 2. Note that your device might need to repeat its list of frequency changes many times before a duplicate frequency is found, and that duplicates might be found while in the middle of processing the list.

>Here are other examples:
+1, -1 first reaches 0 twice.
+3, +3, +4, -2, -4 first reaches 10 twice.
-6, +3, +8, +5, -6 first reaches 5 twice.
+7, +7, -2, -7, -4 first reaches 14 twice.
What is the first frequency your device reaches twice?